### PR TITLE
refactor for graceful failing

### DIFF
--- a/elink_2_functions.py
+++ b/elink_2_functions.py
@@ -1,106 +1,128 @@
 # OSTI E-Link 2 documentation https://review.osti.gov/elink2api/
 import requests
-from pprint import pprint
 import mimetypes
 from requests_toolbelt.multipart.encoder import MultipartEncoder
+import cdl_osti_db_functions as cdl
 
 
 # New Metadata submissions
-def submit_new_pubs(pubs_for_metadata_submission, osti_creds):
+def submit_new_pubs(pubs_for_metadata_submission, osti_creds, mysql_creds):
     for pub in pubs_for_metadata_submission:
         print(f"\nSubmitting Publication ID: {pub['id']}")
 
-        response = post_metadata(osti_creds, pub)
-        pub['response_status_code'] = response.status_code
-        pub['response_json'] = response.json()
-        pub['response_success'] = (response.status_code < 300)
+        try:
+            response = post_metadata(osti_creds, pub)
+            pub['response_status_code'] = response.status_code
+            pub['response_json'] = response.json()
+            pub['response_success'] = (response.status_code < 300)
 
-        if pub['response_success']:
-            print("Submission OK.")
-            pub['osti_id'] = pub['response_json']['osti_id']
-        else:
-            print("Submission Failure:")
-            print(pub['response_json'])
+            if pub['response_success']:
+                print("Metadata Submission OK.")
+                pub['osti_id'] = pub['response_json']['osti_id']
+
+                print("Updating CDL DB with response data.")
+                cdl.insert_new_metadata_submission(pub, mysql_creds)
+
+                print(f"Submitting media: Elements ID {pub['id']}, "
+                      f"OSTI ID {pub['osti_id']}, PDF: {pub['File URL']}")
+
+                media_response = post_media(osti_creds, pub)
+                pub['media_response_code'] = media_response.status_code
+                pub['media_response_json'] = media_response.json()
+                pub['media_response_success'] = (media_response.status_code < 300)
+
+                if pub['media_response_success']:
+                    print("Media submission OK.")
+                    pub['media_id'] = media_response.json()['files'][0]['media_id']
+                    pub['media_file_id'] = media_response.json()['files'][0]['media_file_id']
+
+                else:
+                    print(f"Media submission failure: {media_response.status_code}")
+                    print(pub['media_response_json'])
+                    pub['media_id'] = None
+                    pub['media_file_id'] = None
+
+                print("Updating CDL DB with Media data (will include media failure codes).")
+                cdl.update_media_submission(pub, mysql_creds)
+
+            else:
+                print("Submission Failure:")
+                print(pub['response_json'])
+
+        except Exception as e:
+            print(e)
+            print()
+            raise f"Failed while submitting a new record: Elements ID {pub['id']}"
 
     return pubs_for_metadata_submission
 
 
-# New PDF submissions metadata without PDFs.
-def submit_new_pdfs(pubs_for_media_submission, osti_creds):
-    for pub in pubs_for_media_submission:
-        print(f"\nSubmitting media: Elements ID {pub['id']}, "
-              f"OSTI ID {pub['osti_id']} PDF: {pub['File URL']}")
-
-        media_response = post_media(osti_creds, pub)
-        pub['media_response_code'] = media_response.status_code
-        pub['media_response_json'] = media_response.json()
-        pub['media_response_success'] = (media_response.status_code < 300)
-
-        if pub['media_response_success']:
-            print("Media submission OK.")
-            pub['media_id'] = media_response.json()['files'][0]['media_id']
-            pub['media_file_id'] = media_response.json()['files'][0]['media_file_id']
-        else:
-            print(f"Media submission failure: {media_response.status_code}")
-            print(pub['media_response_json'])
-            pub['media_id'] = None
-            pub['media_file_id'] = None
-
-    return pubs_for_media_submission
-
-
 # Update existing OSTI metadata
-def submit_metadata_updates(updated_osti_pubs, osti_creds):
+def submit_metadata_updates(updated_osti_pubs, osti_creds, mysql_creds):
     for pub in updated_osti_pubs:
         print(f"\nSubmitting update: Elements Pub. ID: {pub['id']}, OSTI ID: {pub['osti_id']}")
-        pprint(pub)
 
-        response = put_metadata(osti_creds, pub)
-        pub['response_status_code'] = response.status_code
-        pub['response_json'] = response.json()
-        pub['response_success'] = (response.status_code < 300)
+        try:
+            response = put_metadata(osti_creds, pub)
+            pub['response_status_code'] = response.status_code
+            pub['response_json'] = response.json()
+            pub['response_success'] = (response.status_code < 300)
 
-        if pub['response_success']:
-            print("Metadata Update Submission OK.")
-        else:
-            print("Metadata Update Submission Failure:")
-            print(response.json())
+            if pub['response_success']:
+                print("Metadata Update Submission OK.")
+                print("Updating CDL DB with response data.")
+                cdl.update_osti_db_metadata(pub, mysql_creds)
+
+            else:
+                print("Metadata Update Submission Failure:")
+                print(response.json())
+
+        except Exception as e:
+            print(e)
+            print()
+            raise f"Failed while submitting a metadata update: Elements ID {pub['id']}"
 
     return updated_osti_pubs
 
 
 # Replace PDF, or try a new PDF if the eSchol OSTI DB contains an error response.
-def submit_media_updates(updated_media_pubs, osti_creds):
-
+def submit_media_updates(updated_media_pubs, osti_creds, mysql_creds):
     for pub in updated_media_pubs:
         print(f"\nSubmitting media update: Elements ID {pub['id']}, OSTI ID {pub['osti_id']},"
               f"\nMedia ID: {pub['media_id']}, Media File ID: {pub['media_file_id']}"
               f"\nPDF: {pub['File URL']}")
 
-        pprint(pub)
+        try:
+            # A null media_id means there was an error with the first pdf submission,
+            # so it requires a post() b/c no media file currently exists.
+            media_response = None
+            if pub['media_id'] is None or 'media_id' not in pub.keys():
+                print("No media file ID: New PDF submission.")
+                media_response = post_media(osti_creds, pub)
+            else:
+                print("Existing file ID: Updating PDF.")
+                media_response = put_media(osti_creds, pub)
 
-        # A null media_id means there was an error with the first pdf submission,
-        # so it requires a post() b/c no media file currently exists.
-        media_response = None
-        if pub['media_id'] is None or 'media_id' not in pub.keys():
-            print("No media file ID: New PDF submission.")
-            media_response = post_media(osti_creds, pub)
-        else:
-            print("Existing file ID: Updating PDF.")
-            media_response = put_media(osti_creds, pub)
+            pub['media_response_code'] = media_response.status_code
+            pub['media_response_json'] = media_response.json()
+            pub['media_response_success'] = (media_response.status_code < 300)
 
-        pub['media_response_code'] = media_response.status_code
-        pub['media_response_json'] = media_response.json()
-        pub['media_response_success'] = (media_response.status_code < 300)
+            if pub['media_response_success']:
+                print("Media update OK.")
+                pub['media_id'] = media_response.json()['files'][0]['media_id']
+                pub['media_file_id'] = media_response.json()['files'][0]['media_file_id']
+            else:
+                print(f"Media update failure: {media_response.status_code}")
+                pub['media_id'] = None
+                pub['media_file_id'] = None
 
-        if pub['media_response_success']:
-            print("Media update OK.")
-            pub['media_id'] = media_response.json()['files'][0]['media_id']
-            pub['media_file_id'] = media_response.json()['files'][0]['media_file_id']
-        else:
-            print(f"Media update failure: {media_response.status_code}")
-            pub['media_id'] = None
-            pub['media_file_id'] = None
+            print("Updating CDL DB with Media data (will include media failure codes).")
+            cdl.update_media_submission(pub, mysql_creds)
+
+        except Exception as e:
+            print(e)
+            print()
+            raise f"Failed while updating a PDF: Elements ID {pub['id']}"
 
     return updated_media_pubs
 
@@ -135,7 +157,6 @@ def post_media(osti_creds, pub):
     headers = {'Authorization': 'Bearer ' + osti_creds['token'],
                'Content-Type': mp_encoder.content_type}
     params = {'title': pub['title']}
-    # params = {'url': pub['File URL'], 'title': pub['title']}
 
     # Send the post with the PDF data
     media_response = requests.post(
@@ -153,13 +174,11 @@ def put_media(osti_creds, pub):
     pdf_response.raw.decode_content = True
 
     mp_encoder = MultipartEncoder(
-        fields={'file': (pdf_filename, pdf_response.content, 'application/pdf')}
-    )
+        fields={'file': (pdf_filename, pdf_response.content, 'application/pdf')})
 
     headers = {'Authorization': 'Bearer ' + osti_creds['token'],
                'Content-Type': mp_encoder.content_type}
     params = {'title': pub['title']}
-    # params = {'url': pub['File URL'], 'title': pub['title']}
 
     # Send the post with the PDF data
     media_response = requests.put(

--- a/program_setup.py
+++ b/program_setup.py
@@ -54,11 +54,12 @@ def process_args():
                         default=False,
                         help="Outputs update XML or JSON to disk rather than sending to OSTI API.")
 
-    parser.add_argument("-xu", "--test-updates",
-                        dest="test_updates",
+    parser.add_argument("-uo", "--updates-only",
+                        dest="updates_only",
                         action="store_true",
                         default=False,
-                        help="Skips ordinary submission step and jumps to update steps.")
+                        help=("Skips ordinary submission step only runs updates. "
+                              "Will exit if not also run with -mu (media updates) or -pu (pdf updates)."))
 
     parser.add_argument("-fl", "--full-logging",
                         dest="full_logging",

--- a/sql_files/get_updated_pdfs_from_elements.sql
+++ b/sql_files/get_updated_pdfs_from_elements.sql
@@ -68,6 +68,7 @@ FROM
 		AND prf.[Proprietary ID] NOT LIKE ('%/supp/%')
 
     -- Has already been sent to OSTI
+    -- And is after the E-Link 2 switchover.
     JOIN #osti_submitted os
 		ON (    os.[doi] = pr.[doi]
 		    OR os.[eschol_id] = pr.[Data Source Proprietary ID]
@@ -75,13 +76,11 @@ FROM
 		AND os.osti_id >= 2568336
 
 WHERE
-	-- Primary file is different from what we have on record
-	os.[prf_filename] is not NULL
-	AND (
-	        (os.[prf_filename] != prf.[Filename] OR os.[prf_size] != prf.[Size])
-	        OR
-	        (os.[media_response_code] IS NOT NULL AND os.[media_response_code] > 300)
-	    )
+    -- No media submission or the prf.[index]=0 file has changed
+    os.[media_response_code] is NULL
+	OR os.[media_response_code] > 300
+	OR os.[prf_filename] != prf.[Filename]
+	OR os.[prf_size] != prf.[Size]
 
 	-- INDIVIDUAL UPDATES PUB ID LIST REPLACE
 


### PR DESCRIPTION
### Refactoring for better error handling

### Why?

During the past few weeks, we've had a few instances where OSTI's connection has dropped, causing the program to stall out. The program's setup left several "loose ends" that had to be cleaned up manually in the DBs when this occurred.

This update refactors the program:

FROM: submitting _all the items_ to an individual API or DB, the the next API or DB

TO: submitting _a single item_ to each API and DB sequentially.

This creates a slightly more complex execution flow, but is significantly better for error handling. Additional try/except blocks were also added for full stack traces and succinct messages with raise()